### PR TITLE
Human readable floats for temperature in print_weather function.

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -589,8 +589,8 @@ pub fn print_weather(weather: CurrentWeather) -> String {
         Err(_) => "Failed to parse time".to_string(),
     };
 
-    let celsius = weather.main.temp.round();
-    let fahrenheit = ((weather.main.temp * (9.0 / 5.0)) + 32_f64).round();
+    let celsius = weather.main.temp.round_human();
+    let fahrenheit = ((weather.main.temp * (9.0 / 5.0)) + 32_f64).round_human();
 
     let metric_wind = weather.wind.speed.round();
     let imperial_wind = (weather.wind.speed * 2.2369_f64).round();
@@ -802,4 +802,18 @@ fn graph(initial: f32, prices: Vec<f32>) -> String {
     }
 
     v
+}
+
+trait HumanReadableRound {
+    fn round_human(self) -> f64;
+}
+
+impl HumanReadableRound for f64 {
+    fn round_human(self) -> f64 {
+        if self > -0.5 && self <= -0.0 {
+            0.00
+        } else {
+            self.round()
+        }
+    }
 }


### PR DESCRIPTION
HumanReadableRound trait implements 'fn human_round(self) -> f64', and this function as implemented for f64 is a simple wrapper around round() to provide a positive sum for floats between -0.00 and -0.499.

For celsius and fahrenheit local variables in the print_weather function, calls to round() have been changed to round_human().